### PR TITLE
Implementing more dunder methods, adding support for subscripting and slicing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # ShortSeq
 
-ShortSeqs are compact and efficient Python objects that hold short sequences while using up to 73% less memory compared to built-in types. They have a pre-computed hash value, can be compared for equality, and are easily converted back to the original sequence string.
+ShortSeqs are compact and efficient Python objects that hold short sequences while using up to 73% less memory compared to built-in types. They are prehashed and comparable, they support slicing and indexing, and they easily convert back to their original string form.
 
-
-| Sequence Length | PyUnicode Size<sup>*</sup> | PyBytes Size<sup>*</sup> | ShortSeq Size<sup>*</sup> | % Reduction |
-|-----------------|----------------------------|--------------------------|---------------------------|-------------|
-| 0-32 nt         | 56-88 bytes                | 40-72 bytes              | 32 bytes (fixed)          | **20-64%**  |
-| 33-64 nt        | 88-120 bytes               | 72-104 bytes             | 48 bytes (fixed)          | **33-60%**  |
-| 65-1024 nt      | 120-1080 bytes             | 104-1064 bytes           | 48-288 bytes              | **53-73%**  |
+| Sequence Length | PyUnicode Size<sup>*</sup> | PyBytes Size<sup>*</sup> |  ShortSeq Size<sup>*</sup> | % Mem. Reduction |
+|-----------------|----------------------------|--------------------------|---------------------------:|------------------|
+| 0-32 nt         | 56-88 bytes                | 40-72 bytes              |           32 bytes (fixed) | **20-64%**       |
+| 33-64 nt        | 88-120 bytes               | 72-104 bytes             |           48 bytes (fixed) | **33-60%**       |
+| 65-1024 nt      | 120-1080 bytes             | 104-1064 bytes           |               48-288 bytes | **53-73%**       |
 
 <sup>* Object sizes were measured on Python 3.10 using `asizeof()` from the `pympler` package.</sup>
 
-### CPU Requirements
+In the table above, you can see that Python's memory representation of DNA sequences is larger than a C-style `char *` array, which would only need one byte per base. Using Cython we can move some of this memory representation out of Python space and into C space for faster facilities and a more compact bitwise representation.  
 
-Your processor must support BMI2 instructions. Roughly speaking, this includes:
-- Intel Haswell (2014) and newer
-- AMD Excavator (2015) and newer
-- Apple M1 and newer
 
-However, AMD processors [prior to Zen 3](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set#cite_ref-12) (2020) aren't recommended for 65-1024 nt sequences if runtime performance is a high priority.
+### Installation
+
+```shell
+mamba install -c bioconda shortseq
+```
+
 
 ### Usage
+
 ```python
 from ShortSeq import ShortSeq, ShortSeqCounter
 
@@ -28,7 +29,7 @@ from ShortSeq import ShortSeq, ShortSeqCounter
 seq_str = "ATGC"
 seq_1 = ShortSeq.from_str(seq_str)
 
-# Construct from PyBytes
+# Or, construct from PyBytes
 seq_bytes = b"ATGC"
 seq_2 = ShortSeq.from_bytes(seq_bytes)
 
@@ -42,6 +43,15 @@ counts = ShortSeqCounter([seq_bytes] * 10)
 assert counts == {ShortSeq.from_str("ATGC"): 10}
 ```
 
+### CPU Requirements
+
+- Intel Haswell (2014) and newer, or
+- AMD Excavator (2015) and newer, or
+- Apple M1 and newer
+
+However, AMD processors [prior to Zen 3](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set#cite_ref-12) (2020) aren't recommended for 65-1024 nt sequences if runtime performance is a high priority.
+
+
 ### Encoding (Compression)
 
 We represent DNA with four symbols: A, C, T, and G. Generally speaking, when these symbols are represented in computer systems, each symbol takes up one byte or 8 bits of memory because these letters are part of a symbol system that requires 7/8 of those bits for its range. These symbols can instead be represented ordinally as 0, 1, 2, and 3, which only requires 2 bits, allowing us to pack 4 nucleotides into each byte rather than just one.
@@ -53,13 +63,24 @@ We represent DNA with four symbols: A, C, T, and G. Generally speaking, when the
 | T          | `0101 10 00` |      `10`       |
 | G          | `0100 11 11` |      `11`       |
 
-When Python holds sequences of DNA in memory as PyUnicode or PyBytes objects, their footprint is even larger and more complex than the ASCII representation shown above. Using Cython we can move this memory representation out of Python space and into C space for better efficiency while still fulfilling the duties of a Python object.
+This table shows how each nucleotide is represented in ASCII and how it's ordinal value is represented in binary. I should mention that this scheme isn't my work, but rather a well-known technique that's been around for a while.
+
 
 ### Decoding
-ShortSeqs are decoded back to their original sequence strings "lazily", i.e. it happens only when you ask and the result isn't cached in the object, so it has to be recomputed with each request. However, ShortSeqs retain the original string's length and ability to be compared for equality without conversion. The packed integer form of each sequence additionally acts as its pre-computed hash value. These two properties make ShortSeqs ideal for use in datastructures like sets and dictionaries, making them useful for efficiently gathering statistics involving very large volumes of short sequences.
+
+ShortSeqs are decoded back to their original sequence strings "lazily", i.e. it happens only when you ask and the result isn't cached in the object, so it has to be recomputed with each request. However, ShortSeqs retain the original string's length and can be compared to each other for equality **without** decoding.
+
 
 ### Overhead
+
 The time it takes to convert a list of PyBytes sequences to a list of ShortSeqs is roughly the same as converting the list to PyUnicode sequences. The time it takes to count unique sequences in each of these lists (ShortSeq vs. PyUnicode) is also roughly the same.
 
+
 ### Longer Sequences, Featuring SIMD Encoding
+
 Longer sequences (65 - 1024 bases) are experimentally supported. These sequences are encoded using SIMD instructions which convert 8 bases at a time for higher throughput. However, sequences of this length are not checked for invalid base characters; it is the user's responsibility to ensure that valid DNA strings are used.
+
+
+### Acknowledgements
+
+Huge thanks to the Montgomery Lab at Colorado State University. This was an experiment of mine that was started in pursuit of faster sequence deduplication and optimization while working on [tinyRNA](https://www.github.com/MontgomeryLab/tinyRNA).

--- a/ShortSeq/__init__.py
+++ b/ShortSeq/__init__.py
@@ -1,4 +1,8 @@
 from .short_seq import ShortSeq, ShortSeqCounter, read_and_count_fastq
-from .short_seq_var import ShortSeqVar
-from .short_seq_128 import ShortSeq128
-from .short_seq_64 import ShortSeq64
+from .short_seq_var import ShortSeqVar, get_domain_var
+from .short_seq_128 import ShortSeq128, get_domain_128
+from .short_seq_64 import ShortSeq64, get_domain_64
+
+MIN_VAR_NT, MAX_VAR_NT = get_domain_var()
+MIN_128_NT, MAX_128_NT = get_domain_128()
+MIN_64_NT,  MAX_64_NT  = get_domain_64()

--- a/ShortSeq/short_seq_128.pxd
+++ b/ShortSeq/short_seq_128.pxd
@@ -1,5 +1,9 @@
 from .short_seq_util cimport *
 
+# Constants
+cdef size_t MIN_128_NT
+cdef size_t MAX_128_NT
+
 # Cython needs help recognizing 128bit integers
 cdef extern from *:
     ctypedef unsigned long long uint128_t "__uint128_t"

--- a/ShortSeq/short_seq_128.pyx
+++ b/ShortSeq/short_seq_128.pyx
@@ -44,6 +44,10 @@ cdef class ShortSeq128:
     def __str__(self):
         return _unmarshall_bytes_128(self._packed, self._length)
 
+    def __repr__(self):
+        return f"<ShortSeq128 ({self._length} nt): {self}>"
+
+
 @cython.wraparound(False)
 @cython.cdivision(True)
 @cython.boundscheck(False)

--- a/ShortSeq/short_seq_128.pyx
+++ b/ShortSeq/short_seq_128.pyx
@@ -35,6 +35,9 @@ cdef class ShortSeq128:
         if type(other) is ShortSeq128:
             return self._length == (<ShortSeq128> other)._length and \
                    self._packed == (<ShortSeq128> other)._packed
+        elif isinstance(other, (str, bytes)):
+            return self._length == len(other) and \
+                   str(self) == other
         else:
             return False
 

--- a/ShortSeq/short_seq_128.pyx
+++ b/ShortSeq/short_seq_128.pyx
@@ -24,6 +24,12 @@ Consider encoding length into lower 6 bits (representing up to 63):
     PyUnicode equivalent: 112 bytes (57% reduction)
 """
 
+MIN_128_NT = 33
+MAX_128_NT = 64
+
+"""Used to export these constants to Python space"""
+def get_domain_128(): return MIN_128_NT, MAX_128_NT
+
 cdef class ShortSeq128:
     def __hash__(self):
         return <uint64_t>self._packed

--- a/ShortSeq/short_seq_64.pxd
+++ b/ShortSeq/short_seq_64.pxd
@@ -1,5 +1,9 @@
 from .short_seq_util cimport *
 
+# Constants
+cdef size_t MIN_64_NT
+cdef size_t MAX_64_NT
+
 # Reusable buffer for unmarshalling
 cdef char out_ascii_buffer_32[32]
 

--- a/ShortSeq/short_seq_64.pyx
+++ b/ShortSeq/short_seq_64.pyx
@@ -45,6 +45,9 @@ cdef class ShortSeq64:
     def __hash__(self) -> uint64_t:
         return self._packed
 
+    def __len__(self):
+        return self._length
+
     def __eq__(self, other):
         if type(other) is ShortSeq64:
             return self._length == (<ShortSeq64>other)._length and \
@@ -58,8 +61,9 @@ cdef class ShortSeq64:
     def __str__(self):
         return _unmarshall_bytes_64(self._packed, self._length)
 
-    def __len__(self):
-        return self._length
+    def __repr__(self):
+        return f"<ShortSeq64 ({self._length} nt): {self}>"
+
 
 @cython.wraparound(False)
 @cython.cdivision(True)

--- a/ShortSeq/short_seq_64.pyx
+++ b/ShortSeq/short_seq_64.pyx
@@ -23,6 +23,13 @@ Consider if length was encoded into the lower 6 bits (representing up to 63):
     PyUnicode equivalent: 80 bytes (60% reduction)
 """
 
+# Constants
+MIN_64_NT = 0
+MAX_64_NT = 32
+
+"""Used to export these constants to Python space"""
+def get_domain_64(): return MIN_64_NT, MAX_64_NT
+
 cdef class ShortSeq64:
     # Todo: decide whether to standardize or remove (esp. setter...)
 

--- a/ShortSeq/short_seq_64.pyx
+++ b/ShortSeq/short_seq_64.pyx
@@ -65,6 +65,26 @@ cdef class ShortSeq64:
         else:
             return False
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def __getitem__(self, item):
+        cdef Py_ssize_t index, start, stop, step, slice_len
+
+        if isinstance(item, slice):
+            if PySlice_GetIndicesEx(item, self._length, &start, &stop, &step, &slice_len) < 0:
+                raise Exception("Slice error")
+            if step != 1:
+                raise TypeError("Slice step not supported")
+            return _unmarshall_bytes_64(self._packed >> (start * 2), slice_len)
+        elif isinstance(item, int):
+            index = item
+            if index < 0: index += self._length
+            if index < 0 or index >= self._length:
+                raise IndexError("Sequence index out of range")
+            return _unmarshall_bytes_64(self._packed >> (index * 2), 1)
+        else:
+            raise TypeError(f"Invalid index type: {type(item)}")
+
     def __str__(self):
         return _unmarshall_bytes_64(self._packed, self._length)
 

--- a/ShortSeq/short_seq_64.pyx
+++ b/ShortSeq/short_seq_64.pyx
@@ -49,6 +49,9 @@ cdef class ShortSeq64:
         if type(other) is ShortSeq64:
             return self._length == (<ShortSeq64>other)._length and \
                    self._packed == (<ShortSeq64>other)._packed
+        elif isinstance(other, (str, bytes)):
+            return self._length == len(other) and \
+                   str(self) == other
         else:
             return False
 

--- a/ShortSeq/short_seq_util.pxd
+++ b/ShortSeq/short_seq_util.pxd
@@ -93,3 +93,13 @@ cdef inline bint is_array_equal(uint64_t* a, uint64_t* b, size_t length) nogil:
         if a[i] != b[i]: return False
 
     return True
+
+
+"""
+Performs euclidean division and remainder and returns the result as a pair.
+This is essentially the C version of Python's divmod function. Note that
+Python-style modulo is performed and not C-style remainder, so this should
+still give expected values for negative numbers.
+"""
+
+cdef (size_t, size_t) _divmod(size_t dividend, size_t divisor)

--- a/ShortSeq/short_seq_util.pxd
+++ b/ShortSeq/short_seq_util.pxd
@@ -5,6 +5,7 @@ from libcpp.cast cimport reinterpret_cast
 
 from cpython.object cimport Py_SIZE, PyObject
 from cpython.ref cimport Py_XDECREF, Py_XINCREF
+from cpython.slice cimport PySlice_GetIndicesEx, PySlice_AdjustIndices
 from cpython.unicode cimport PyUnicode_DecodeASCII
 
 

--- a/ShortSeq/short_seq_util.pyx
+++ b/ShortSeq/short_seq_util.pyx
@@ -1,5 +1,20 @@
-# These values must be assigned here in order for the definition
-# (and not just the declaration) to be correctly cimported
+import cython
+
+@cython.cdivision(True)
+cdef inline (size_t, size_t) _divmod(size_t dividend, size_t divisor):
+    cdef size_t div_res
+    cdef size_t mod_res
+
+    if divisor == 0: raise ZeroDivisionError()
+    div_res = dividend // divisor
+    mod_res = (((dividend % divisor) + divisor) % divisor)
+
+    return div_res, mod_res
+
+"""
+These values must be assigned here in order for the definition
+(and not just the declaration) to be correctly cimported
+"""
 
 cdef uint8_t[91] table_91 = [
     4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,

--- a/ShortSeq/short_seq_var.pxd
+++ b/ShortSeq/short_seq_var.pxd
@@ -25,4 +25,4 @@ cdef uint64_t* _marshall_bytes_var(uint8_t* seq_bytes, size_t length)
 cdef uint64_t _marshall_bytes_pext_u64(uint64_t block, uint8_t* &seq_bytes, size_t n_pext) nogil
 cdef uint64_t _marshall_bytes_pext_u32(uint64_t block, uint8_t* &seq_bytes, size_t n_pext) nogil
 cdef uint64_t _marshall_bytes_serial(uint64_t block, uint8_t* &seq_bytes, size_t length) nogil
-cdef unicode _unmarshall_bytes_var(uint64_t* enc_seq, size_t length)
+cdef unicode _unmarshall_bytes_var(uint64_t* enc_seq, size_t length, size_t start_block=*, size_t offset=*)

--- a/ShortSeq/short_seq_var.pxd
+++ b/ShortSeq/short_seq_var.pxd
@@ -1,6 +1,7 @@
 from .short_seq_util cimport *
 from cpython.mem cimport PyObject_Calloc, PyObject_Free
 from libc.math cimport ceil
+from libc.string cimport memcmp
 
 # For Cython, this is necessary for using these types in brackets (reinterpret_cast)
 ctypedef uint64_t* llstr

--- a/ShortSeq/short_seq_var.pxd
+++ b/ShortSeq/short_seq_var.pxd
@@ -3,6 +3,11 @@ from cpython.mem cimport PyObject_Calloc, PyObject_Free
 from libc.math cimport ceil
 from libc.string cimport memcmp
 
+# Constants
+cdef size_t MAX_VAR_NT
+cdef size_t MIN_VAR_NT
+cdef size_t MAX_REPR_LEN
+
 # For Cython, this is necessary for using these types in brackets (reinterpret_cast)
 ctypedef uint64_t* llstr
 ctypedef uint32_t* istr

--- a/ShortSeq/short_seq_var.pyx
+++ b/ShortSeq/short_seq_var.pyx
@@ -8,6 +8,9 @@ cdef class ShortSeqVar:
     def __hash__(self):
         return deref(self._packed)
 
+    def __len__(self):
+        return self._length
+
     def __eq__(self, other):
         if type(other) is ShortSeqVar:
             other_len = (<ShortSeqVar>other)._length
@@ -23,8 +26,10 @@ cdef class ShortSeqVar:
     def __str__(self):
         return _unmarshall_bytes_var(self._packed, self._length)
 
-    def __len__(self):
-        return self._length
+    def __repr__(self):
+        # Clips the sequence to MAX_REPR_LEN characters to avoid overwhelming the debugger
+        cdef unicode clipped_seq = _unmarshall_bytes_var(self._packed, MAX_REPR_LEN)
+        return f"<ShortSeqVar ({self._length} nt): {self} ... >"
 
     def __dealloc__(self):
         if self._packed is not NULL:

--- a/ShortSeq/short_seq_var.pyx
+++ b/ShortSeq/short_seq_var.pyx
@@ -34,6 +34,31 @@ cdef class ShortSeqVar:
         else:
             return False
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def __getitem__(self, item):
+        cdef Py_ssize_t index, start, stop, step, slice_len
+        cdef size_t block_idx, block_offset
+
+        if isinstance(item, slice):
+            if PySlice_GetIndicesEx(item, self._length, &start, &stop, &step, &slice_len) < 0:
+                raise Exception("Slice error")
+            if step != 1:
+                raise TypeError("Slice step not supported")
+
+            block_idx, block_offset = _locate_idx(start)
+            return _unmarshall_bytes_var(self._packed, slice_len, block_idx, block_offset)
+        elif isinstance(item, int):
+            index = item
+            if index < 0: index += self._length
+            if index < 0 or index >= self._length:
+                raise IndexError("Sequence index out of range")
+
+            block_idx, block_offset = _locate_idx(index)
+            return _unmarshall_bytes_var(self._packed, 1, block_idx, block_offset)
+        else:
+            raise TypeError(f"Invalid index type: {type(item)}")
+
     def __str__(self):
         return _unmarshall_bytes_var(self._packed, self._length)
 
@@ -46,27 +71,50 @@ cdef class ShortSeqVar:
         if self._packed is not NULL:
             PyObject_Free(<void *>self._packed)
 
+@cython.cdivision(True)
+cdef inline size_t _length_to_block_num(size_t length):
+    """Returns the number of 64-bit blocks needed to store the given length."""
 
-cdef inline unicode _unmarshall_bytes_var(uint64_t* enc_seq, size_t length):
+    return <size_t>ceil(<double>length / <double>NT_PER_BLOCK)
+
+@cython.cdivision(True)
+cdef inline (size_t, size_t) _locate_idx(size_t index):
+    """Returns the block index and offset (in packed units) where the given index (in nt units) is located."""
+
+    cdef size_t block_idx = index // NT_PER_BLOCK
+    cdef size_t block_offset = 2 * (index % NT_PER_BLOCK)
+    return block_idx, block_offset
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+cdef inline unicode _unmarshall_bytes_var(uint64_t* enc_seq, size_t length, size_t start_block=0, size_t offset=0):
     cdef:
         uint64_t block
-        size_t num_blocks = <size_t>ceil(<double>length / 32.0)
-        size_t i, j, lo, hi
+        size_t blocks_spanned = _length_to_block_num(length) + 1
+        size_t hi = min(length, (64 - offset) // 2)
+        size_t rem = length
+        size_t lo = 0
+        size_t i, j
 
-    for i in range(num_blocks):
+    for i in range(start_block, start_block + blocks_spanned):
         block = enc_seq[i]
-        lo = i * 32
-        hi = lo + min(32, length)
+        if i == start_block and offset:
+            block >>= offset
+
         for j in range(lo, hi):
             out_ascii_buffer_var[j] = charmap[block & mask]
             block >>= 2
+
+        rem -= hi - lo
+        lo = hi
+        hi += min(rem, NT_PER_BLOCK)
 
     return PyUnicode_DecodeASCII(out_ascii_buffer_var, length, NULL)
 
 @cython.wraparound(False)
 cdef uint64_t* _marshall_bytes_var(uint8_t* seq_bytes, size_t length):
     cdef:
-        size_t n_blocks = <size_t>ceil(<double>length / 32.0)
+        size_t n_blocks = _length_to_block_num(length)
         uint64_t* hash_arr = <llstr>PyObject_Calloc(n_blocks, sizeof(uint64_t))
         uint8_t* seq_it = seq_bytes
         size_t seq_rem = length
@@ -80,16 +128,12 @@ cdef uint64_t* _marshall_bytes_var(uint8_t* seq_bytes, size_t length):
         raise MemoryError(f"Error while allocating new ShortSeq of length {length}.")
 
     for i in range(n_blocks):
-        block_rem = min(32, seq_rem)
+        block_rem = min(seq_rem, NT_PER_BLOCK)
         seq_rem -= block_rem
         block = 0LL
 
-        n_p64 = <size_t>(block_rem / 8)
-        p64_rem = block_rem % 8
-
-        n_p32 = <size_t>(p64_rem / 4)
-        serial = p64_rem % 4
-
+        n_p64, p64_rem = _divmod(block_rem, 8)
+        n_p32, serial = _divmod(p64_rem, 4)
         offset_p64 = n_p64 * 8
         offset_p32 = n_p32 * 4
 

--- a/ShortSeq/short_seq_var.pyx
+++ b/ShortSeq/short_seq_var.pyx
@@ -4,6 +4,17 @@ cimport cython
 
 from cython.operator cimport dereference as deref
 
+# Importable constants
+MIN_VAR_NT = 65
+MAX_VAR_NT = 1024
+MAX_REPR_LEN = 75
+
+# Constants
+cdef size_t NT_PER_BLOCK = 32
+
+"""Used to export these constants to Python space"""
+def get_domain_var(): return MIN_VAR_NT, MAX_VAR_NT
+
 cdef class ShortSeqVar:
     def __hash__(self):
         return deref(self._packed)

--- a/ShortSeq/short_seq_var.pyx
+++ b/ShortSeq/short_seq_var.pyx
@@ -10,8 +10,13 @@ cdef class ShortSeqVar:
 
     def __eq__(self, other):
         if type(other) is ShortSeqVar:
-            return self._length == (<ShortSeqVar>other)._length and \
-                   is_array_equal(self._packed, (<ShortSeqVar>other)._packed, self._length)
+            other_len = (<ShortSeqVar>other)._length
+            other_ptr = (<ShortSeqVar>other)._packed
+            return self._length == other_len and \
+                memcmp(self._packed, <void *>other_ptr, self._length) == 0
+        elif isinstance(other, (str, bytes)):
+            return self._length == len(other) and \
+                   str(self) == other
         else:
             return False
 

--- a/ShortSeq/tests/unit_tests_main.py
+++ b/ShortSeq/tests/unit_tests_main.py
@@ -2,7 +2,8 @@ import unittest
 import time
 
 from ShortSeq import ShortSeq, ShortSeq64, ShortSeq128, ShortSeqVar
-from .util import rand_sequence
+from ShortSeq import MIN_VAR_NT, MAX_VAR_NT, MIN_64_NT, MAX_64_NT, MIN_128_NT, MAX_128_NT
+from ShortSeq.tests.util import rand_sequence, print_var_seq_pext_chunks
 
 resources = "./testdata"
 
@@ -16,46 +17,41 @@ class ShortSeqFixedWidthTests(unittest.TestCase):
         seq_u = ShortSeq.from_str("")
         seq_b = ShortSeq.from_bytes(b"")
 
-        self.assertEqual(seq_b, seq_u)
-        self.assertEqual(id(seq_b), id(seq_u))
-        self.assertEqual(str(seq_b), "")
-        self.assertEqual(str(seq_u), "")
+        self.assertEqual(seq_b, seq_u)          # ShortSeq-ShortSeq equality
+        self.assertEqual(id(seq_b), id(seq_u))  # singleton
+        self.assertEqual(str(seq_b), "")        # decoded string
+        self.assertEqual(str(seq_u), "")        # decoded string
+        self.assertEqual(seq_b, "")             # __eq__ with bytes argument
+        self.assertEqual(seq_u, "")             # __eq__ with str argument
 
     """Can ShortSeqs encode and decode all valid bases from str object inputs?"""
 
     def test_single_base_str(self):
         bases = [ShortSeq.from_str(b) for b in "ATGC"]
-        self.assertTrue(all(type(b) is ShortSeq64 for b in bases))
-        self.assertListEqual([str(b) for b in bases], list("ATGC"))
+
+        self.assertListEqual(bases, list("ATGC"))                    # __eq__ with str argument
+        self.assertListEqual([str(b) for b in bases], list("ATGC"))  # decoded string
+        self.assertTrue(all(type(b) is ShortSeq64 for b in bases))   # appropriate type
 
     """Can ShortSeqs encode and decode all valid bases from bytes object inputs?"""
 
     def test_single_base_bytes(self):
         to_bytes = lambda x: x.encode()
         bases = [ShortSeq.from_bytes(to_bytes(b)) for b in "ATGC"]
-        self.assertTrue(all(type(b) is ShortSeq64 for b in bases))
-        self.assertListEqual([str(b) for b in bases], list("ATGC"))
+
+        self.assertListEqual(bases, list("ATGC"))                    # __eq__ with str argument
+        self.assertListEqual([str(b) for b in bases], list("ATGC"))  # decoded string
+        self.assertTrue(all(type(b) is ShortSeq64 for b in bases))   # appropriate type
 
     """Does ShortSeq correctly transition to a larger representative object
     when sequence length crosses the 32 base threshold?"""
 
     def test_correct_subtype_for_length(self):
-        seq_32 = ShortSeq.from_str("A" * 32)
-        seq_33 = ShortSeq.from_str("A" * 33)
+        seq_32 = ShortSeq.from_str("A" * MAX_64_NT)
+        seq_33 = ShortSeq.from_str("A" * (MAX_64_NT + 1))
 
         self.assertIsInstance(seq_32, ShortSeq64)
         self.assertIsInstance(seq_33, ShortSeq128)
-
-    """Is maximum sequence length correctly enforced?"""
-
-    def test_max_length_exceeded(self):
-        max_seq = "ATGC" * 256  # 1024 bases, the maximum allowed
-        exc_seq = max_seq + "A"
-        no_problem = ShortSeq.from_str(max_seq)
-        self.assertEqual(str(no_problem), max_seq)
-
-        with self.assertRaisesRegex(Exception, r"(.*)longer than 1024 bases(.*)"):
-            ShortSeq.from_str(exc_seq)
 
     """Are incompatible sequence characters rejected?"""
 
@@ -75,7 +71,7 @@ class ShortSeqVarTests(unittest.TestCase):
     when sequence length crosses the 64 base threshold?"""
 
     def test_min_length(self):
-        sample_len = 65
+        sample_len = MIN_VAR_NT
         n_samples = 3
 
         for _ in range(n_samples):
@@ -85,6 +81,17 @@ class ShortSeqVarTests(unittest.TestCase):
             self.assertIsInstance(sq, ShortSeqVar)
             self.assertEqual(len(sq), len(sample))
             self.assertEqual(str(sq), sample)
+
+    """Is maximum sequence length correctly enforced?"""
+
+    def test_max_length(self):
+        max_seq = "ATGC" * 256  # 1024 bases, the maximum allowed
+        exc_seq = max_seq + "A"
+        no_problem = ShortSeq.from_str(max_seq)
+        self.assertEqual(str(no_problem), max_seq)
+
+        with self.assertRaisesRegex(Exception, r"(.*)longer than 1024 bases(.*)"):
+            ShortSeq.from_str(exc_seq)
 
     """Checks that randomly generated sequences encode and decode correctly
     for the entire valid range of lengths."""

--- a/ShortSeq/umi/README.md
+++ b/ShortSeq/umi/README.md
@@ -1,0 +1,1 @@
+This isn't actively developed. Most UMI-specific things are implemented but variable length sequences are not. The parts that remain undeveloped are largely covered by the ShortSeqVar class. Once that is complete it will make more sense to loop back to this. 


### PR DESCRIPTION
`__getitem__()`
ShortSeqs can now be subscripted and sliced like strings, producing a new PyUnicode object (not a new ShortSeq object).

`__eq__()`
- ShortSeqs can now be compared for equality with `str` and `bytes` objects. When this happens, a temporary PyUnicode object is produced which handles the rest of the comparison. For this reason I still recommend using ShortSeq to ShortSeq comparisons when possible.
- Equality checks between ShortSeqVar objects now uses a more efficient method

`__repr__()`
This helps produce more helpful debugging information. The sequence string shown in reprs for ShortSeqVars is truncated to 75 bases to avoid overwhelming the debugger when working with a large quantity of long ShortSeqs.
